### PR TITLE
fixing arch field and tool dependencies

### DIFF
--- a/package_mannawui_index.json
+++ b/package_mannawui_index.json
@@ -14,7 +14,7 @@
 			"category": "Mannawui",
 			"url": "https://github.com/bedreski/mannawui-arduino-interface/releases/download/v1.0.0/MannaWui-1.0.zip",
 			"archiveFileName": "MannaWui-1.0.zip",
-			"checksum": "SHA-256:a7e0919517022e8bc5d34fd2b0ef944c0cfc4c6807d97b8c683415eb13bdda68",
+			"checksum": "SHA-256:3767c575bd62bafa8fe4d9aeb977c63b83b23563f7a18eb861d9ddeaac0380b0",
 			"size": "3310",
 			"help": {
 				"online": "https://github.com/mannalab/mannawui-arduino-interface/blob/master/mannaWUI/readme.txt"

--- a/package_mannawui_index.json
+++ b/package_mannawui_index.json
@@ -9,7 +9,7 @@
 		},
 		"platforms": [{
 			"name": "MannaWUI",
-			"architecture": "avr",
+			"architecture": "stm32",
 			"version": "1.0.0",
 			"category": "Mannawui",
 			"url": "https://github.com/bedreski/mannawui-arduino-interface/releases/download/v1.0.0/MannaWui-1.0.zip",
@@ -22,16 +22,23 @@
 			"boards": [{
 				"name": "MannaWUI"
 			}],
-			"toolsDependencies": [{
-				"packager": "arduino",
-				"name": "avr-gcc",
-				"version": "4.8.1-arduino5"
-			}, {
-				"packager": "arduino",
-				"name": "avrdude",
-				"version": "6.0.1-arduino5"
-			}]
-		}],
+			"toolsDependencies": [
+            		  {
+              			"packager": "STMicroelectronics",
+             			"name": "xpack-arm-none-eabi-gcc",
+              			"version": "9.3.1-1.3"
+            		  },
+            		  {
+              			"packager": "STMicroelectronics",
+              			"name": "STM32Tools",
+              			"version": "2.0.0"
+            		  },
+            		  {
+              			"packager": "STMicroelectronics",
+              			"name": "CMSIS",
+              			"version": "5.7.0"
+            		  }
+		]},
 		
 		"tools": []
 	}]


### PR DESCRIPTION
I was filling the arch field with avr (based on another unofficial board), when it was stm32 and this changes both toolDependencies key/value and the platform.txt file. This file isn't required, but I am reading more about it to see what exactly is need to put there.